### PR TITLE
Pass decimalPlaces prop to CalculatedNumeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ See [demo/src/index.js](demo/src/index.js) for example usage.
 
 ## Changelog
 
+### v0.0.6
+
+Fixes a problem where the decimalPlaces prop wasn't being properly passed to the CalculatedNumeric component.
+
 ### v0.0.5
 
 This is a breaking change that changes the Question component's prop signature from having a single questionData prop to exposing all of the previous questionData properties as individual props.  This allows us to have more flexibility when defining the PropTypes in a separate file and sharing them between different components.
@@ -27,7 +31,6 @@ Changes include:
 - Code style updates
 - CSS updates with SASS placeholders and hyphen-case
 
-
 ### v0.0.4
 
 Changes include:
@@ -40,11 +43,13 @@ Changes include:
 - Remove i18n for CN question type
 
 ### v0.0.3
+
 Package moved to @bostonuniversity org
 
 ### v0.0.2
 
 Assume all questions have a correct and incorrect feedback.
+
 ```json
 {
   "feedback": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bostonuniversity/react-questions",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "react-questions React component library for questions",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/Question.js
+++ b/src/Question.js
@@ -109,7 +109,7 @@ class Question extends React.Component {
   // Renders the correct question type.
   renderAnswerComponent = () => {
     const {
-      type, header, body, answer, answers, feedback,
+      type, header, body, answer, answers, feedback, decimalPlaces = 0,
     } = this.props;
     const { resetCount, submitted: submitState, correct } = this.state;
 
@@ -150,6 +150,7 @@ class Question extends React.Component {
       case 'calculated-numeric':
         return (
           <CalculatedNumeric
+            decimalPlaces={decimalPlaces}
             {...commonProps}
           />
         );

--- a/src/Question.js
+++ b/src/Question.js
@@ -109,7 +109,7 @@ class Question extends React.Component {
   // Renders the correct question type.
   renderAnswerComponent = () => {
     const {
-      type, header, body, answer, answers, feedback, decimalPlaces = 0,
+      type, header, body, answer, answers, feedback, decimalPlaces = '0',
     } = this.props;
     const { resetCount, submitted: submitState, correct } = this.state;
 


### PR DESCRIPTION
The calculated numeric is the only question that has the decimalPlaces prop.  Now that we are passing the destructured question object to the components, we need to explicitly pass it to the `<CalculatedNumeric>` component in the main Question component.

This change pulls `decimalPlaces` with the other question properties, initializing it to `0` if it isn't present.