### PR TITLE
Linting fixups

### DIFF
--- a/src/Question.js
+++ b/src/Question.js
@@ -155,6 +155,7 @@ class Question extends React.Component {
           />
         );
       default:
+        // eslint-disable-next-line no-console
         console.error(`'${type}' is not a recognized question type.`);
         return null;
     }

--- a/src/Question.scss
+++ b/src/Question.scss
@@ -1,34 +1,35 @@
 .question {
-  background: rgb(238, 238, 238);
-  padding: 1rem;
-  margin: 1rem 0;
+  background: rgb( 238, 238, 238 );
+  margin: 1em 0;
+  padding: 1em;
 
   .header {
     font-style: italic;
   }
-  
+
   .body {
-    margin-top: .2em;
-    margin-bottom: .2em;
+    margin-bottom: 0.2em;
+    margin-top: 0.2em;
   }
   
   .feedback {
-    margin: .2em;
+    margin: 0.2em;
   }
 
   .question-icon, %question-icon {
-    font-size: 2.5em;
     display: inline-block;
-    vertical-align: middle;
+    font-size: 2.5em;
     margin-right: .1em;
+    vertical-align: middle;
 
     &-correct {
       @extend %question-icon;
-      color: rgb(75, 173, 56);
+      color: rgb( 75, 173, 56 );
     }
+
     &-incorrect {
       @extend %question-icon;
-      color: rgb(170, 50, 50);
+      color: rgb( 170, 50, 50 );
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
 export { default as Question } from './Question';

--- a/src/questions/CalculatedNumeric.js
+++ b/src/questions/CalculatedNumeric.js
@@ -19,7 +19,6 @@ class CalculatedNumeric extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      pristine: true,
       valid: null,
       errors: [],
       answer: '',
@@ -101,7 +100,6 @@ class CalculatedNumeric extends React.Component {
 
     // Update component state.
     this.setState({
-      pristine,
       valid,
       errors,
       answer,

--- a/src/questions/CalculatedNumeric.js
+++ b/src/questions/CalculatedNumeric.js
@@ -124,6 +124,8 @@ class CalculatedNumeric extends React.Component {
           <div>
             <ul>
               {errors.map((error, index) => (
+                // There is only ever going to be one error, so accept array index as key.
+                // eslint-disable-next-line react/no-array-index-key
                 <li key={index}>{error}</li>
               ))}
             </ul>

--- a/src/questions/MultipleAnswer.js
+++ b/src/questions/MultipleAnswer.js
@@ -95,6 +95,8 @@ class MultipleAnswer extends React.Component {
 
       return (
         <TextListAnswer
+          // Multiple answer order never changes, so accept array index as key.
+          // eslint-disable-next-line react/no-array-index-key
           key={index}
           answer={answer}
           selected={selected}

--- a/src/questions/MultipleAnswer.js
+++ b/src/questions/MultipleAnswer.js
@@ -22,7 +22,6 @@ class MultipleAnswer extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      pristine: true,
       selectedAnswers: [],
     };
   }
@@ -61,7 +60,6 @@ class MultipleAnswer extends React.Component {
 
     // Update component state.
     this.setState({
-      pristine,
       selectedAnswers: newSelectedAnswers,
     });
 

--- a/src/questions/MultipleChoice.js
+++ b/src/questions/MultipleChoice.js
@@ -78,6 +78,8 @@ class MultipleChoice extends React.Component {
 
       return (
         <TextListAnswer
+          // Multiple choice order never changes, so accept array index as key.
+          // eslint-disable-next-line react/no-array-index-key
           key={index}
           answer={answer}
           selected={selected}

--- a/src/questions/MultipleChoice.js
+++ b/src/questions/MultipleChoice.js
@@ -24,7 +24,6 @@ class MultipleChoice extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      pristine: true,
       selectedAnswer: null,
     };
   }
@@ -46,7 +45,6 @@ class MultipleChoice extends React.Component {
 
     // Update component state.
     this.setState({
-      pristine,
       selectedAnswer: index,
     });
 

--- a/src/questions/TrueFalse.js
+++ b/src/questions/TrueFalse.js
@@ -76,7 +76,7 @@ class TrueFalse extends React.Component {
 
       return (
         <TextListAnswer
-          key={index}
+          key={answer.answer}
           answer={answer}
           type={answerType}
           onChangeAnswer={this.onChangeAnswer}

--- a/src/questions/TrueFalse.js
+++ b/src/questions/TrueFalse.js
@@ -24,7 +24,6 @@ class TrueFalse extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      pristine: true,
       selectedAnswer: null,
     };
   }
@@ -45,7 +44,6 @@ class TrueFalse extends React.Component {
 
     // Update component state.
     this.setState({
-      pristine,
       selectedAnswer: index,
     });
 

--- a/src/questions/common.scss
+++ b/src/questions/common.scss
@@ -8,46 +8,46 @@
     input:disabled {
         opacity: 0;
     }
-    
+
     .answer, %answer {
-        margin: .1em;
-        border: solid .2em;
-        border-radius: .8em;
+        border: solid 0.2em;
+        border-color: rgba( 255, 255, 255, 0 );
+        border-radius: 0.8em;
         box-sizing: border-box;
-        border-color: rgba(255,255,255,0);
-    
+        margin: 0.1em;
+
         &-correct {
             @extend %answer;
-            border-color: rgb(75, 173, 56);
+            border-color: rgb( 75, 173, 56 );
         }
     
         &-incorrect {
             @extend %answer;
-            border-color: rgb(170, 50, 50);
+            border-color: rgb( 170, 50, 50 );
         }
     }
 
     .feedback-icon, %feedback-icon {
-        position: absolute;
         font-size: 2em;
         left: auto;
-        top: auto;
-        margin-top: .36em;
         margin-left: -1.05em;
+        margin-top: 0.36em;
+        position: absolute;
+        top: auto;
 
         &-correct {
             @extend %feedback-icon;
-            color: rgb(75, 173, 56);
+            color: rgb( 75, 173, 56 );
         }
 
         &-incorrect {
             @extend %feedback-icon;
-            color: rgb(170, 50, 50);
+            color: rgb( 170, 50, 50 );
         }
     }
-    
+
     .feedback {
-        margin-left: 3em;
         font-style: italic;
+        margin-left: 3em;
     }
 }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -1,23 +1,23 @@
-import expect from 'expect'
-import React from 'react'
-import {render, unmountComponentAtNode} from 'react-dom'
+import expect from 'expect';
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
 
-import Component from 'src/'
+import Component from 'src/';
 
 describe('Component', () => {
-  let node
+  let node;
 
   beforeEach(() => {
-    node = document.createElement('div')
-  })
+    node = document.createElement('div');
+  });
 
   afterEach(() => {
-    unmountComponentAtNode(node)
-  })
+    unmountComponentAtNode(node);
+  });
 
   it('displays a welcome message', () => {
-    render(<Component/>, node, () => {
-      expect(node.innerHTML).toContain('Welcome to React components')
-    })
-  })
-})
+    render(<Component />, node, () => {
+      expect(node.innerHTML).toContain('Welcome to React components');
+    });
+  });
+});


### PR DESCRIPTION
Various linting fixes, including disabling some rules for specific lines.

Mostly, allowing array indexes to be used for keys in some cases.  This is discouraged, but in cases where the array items aren't re-ordered it may make sense.  See this article for more background:

https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318

Also removes the unused `pristine` state from individual question components, as the `pristine` state is managed by the main Question component.
